### PR TITLE
feat: add .env.example and create generic configuration fallback layout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Supabase Configuration
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SERVICE_ROLE_KEY=
+
+# App API Secrets
+INTERNAL_API_SECRET=
+
+# Resend Mail Configuration
+RESEND_API_KEY=
+
+# Dodo Payments
+DODO_PAYMENTS_API_KEY=
+DODO_WEBHOOK_SECRET=
+
+# Google Vertex AI Credentials (JSON string)
+GOOGLE_CREDENTIALS_JSON=

--- a/README.md
+++ b/README.md
@@ -39,3 +39,31 @@ GetHired is built on a modern, high-performance stack designed for speed and sca
 | **Database/Storage**     | **Supabase (PostgreSQL)**        | Primary database, secure file storage, and real-time user preference tracking.          |
 | **Vector Search Engine** | **`pgvector` (HNSW Index)**      | High-speed similarity search for job and user embeddings, run directly in the database. |
 | **AI/LLM Processing**    | **Vercel AI SDK / FastAPI**      | Used for structured query parsing (Natural Language Search) and external AI re-ranking. |
+
+## Getting Started
+
+### Prerequisites
+
+Ensure you have [Node.js](https://nodejs.org/) (v18+ recommended) installed.
+
+### Installation & Configuration
+
+1. **Clone the repository and install dependencies:**
+   ```bash
+   npm install
+   ```
+
+2. **Configure environment variables:**
+   Create your `.env.local` file from the example template and fill in the required keys:
+   ```bash
+   cp .env.example .env.local
+   ```
+
+### Running the Project
+
+Start the local development server:
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser to view the application.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,8 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import LayoutWrapper from "@/components/LayoutWrapper";
 import { createClient } from "@/lib/supabase/server";
 
+import { hasEnvVars } from "@/utils/utils";
+
 export const metadata: Metadata = {
   title: {
     default: "GetHired - Your smartest path to the perfect job",
@@ -46,6 +48,33 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  if (!hasEnvVars) {
+    return (
+      <html lang="en" className="dark" suppressHydrationWarning>
+        <body className={`${geistSans.className} flex items-center justify-center min-h-screen bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-neutral-900 via-neutral-950 to-neutral-950 text-neutral-100 p-6 font-sans antialiased`}>
+          <div className="max-w-md w-full border border-neutral-800/80 rounded-2xl p-8 bg-neutral-900/50 backdrop-blur-xl shadow-2xl relative overflow-hidden transition-all duration-300 hover:border-neutral-700/80">
+            <div className="absolute top-0 left-0 right-0 h-[3px] bg-gradient-to-r from-amber-500 via-orange-500 to-yellow-500" />
+            
+            <div className="w-12 h-12 rounded-xl bg-amber-500/10 border border-amber-500/20 flex items-center justify-center mb-6 text-amber-500">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+              </svg>
+            </div>
+
+            <h1 className="text-xl font-bold mb-3 tracking-tight text-neutral-50">Configuration Required</h1>
+            <p className="mb-6 text-neutral-400 leading-relaxed text-sm">
+              You do not have the required environment variables. Please add all required environment variables in your <code className="bg-neutral-800/60 px-1.5 py-0.5 rounded text-xs font-mono text-neutral-300">.env.local</code> file to run the project.
+            </p>
+
+            <p className="text-xs text-neutral-500 leading-relaxed">
+              Once you have configured the <code className="bg-neutral-850 px-1 py-0.5 rounded text-neutral-400">.env.local</code> file, restart your development server (<code className="bg-neutral-850 px-1 py-0.5 rounded text-neutral-400">npm run dev</code>).
+            </p>
+          </div>
+        </body>
+      </html>
+    );
+  }
+
   const supabase = await createClient();
   const {
     data: { user },


### PR DESCRIPTION
<img width="498" height="341" alt="Screenshot 2026-06-15 at 7 22 36 AM" src="https://github.com/user-attachments/assets/702b561d-b73e-4dcb-bc1c-0fcc6434dfd9" />






This is what will be shown to a user without the required env instead of the app the nextjs app crashing like it was previously doing. 

I also added a short instruction on starting the application as well as an example variable for the env and a command to clone it in into local env. This way a contributor would only need to put in the values and get the app working in no time.